### PR TITLE
fix: alignment with openid.core and draft 11

### DIFF
--- a/src/authorization-response/Payload.ts
+++ b/src/authorization-response/Payload.ts
@@ -16,10 +16,9 @@ export const createResponsePayload = async (
   if (!authorizationRequest) {
     throw new Error(SIOPErrors.NO_REQUEST);
   }
-  const state: string = await authorizationRequest.getMergedProperty('state');
-  if (!state) {
-    throw Error('No state');
-  }
+
+  // If state was in request, it must be in response
+  const state: string | undefined = await authorizationRequest.getMergedProperty('state');
 
   const responsePayload: AuthorizationResponsePayload = {
     ...(responseOpts.accessToken && { access_token: responseOpts.accessToken }),

--- a/src/id-token/IDToken.ts
+++ b/src/id-token/IDToken.ts
@@ -37,12 +37,7 @@ export class IDToken {
     if (!authorizationRequestPayload) {
       throw new Error(SIOPErrors.NO_REQUEST);
     }
-    const mergedPayloads = await verifiedAuthorizationRequest.authorizationRequest.mergedPayloads();
-    const idToken = new IDToken(
-      null,
-      await createIDTokenPayload(mergedPayloads, responseOpts, verifiedAuthorizationRequest.requestObject),
-      responseOpts
-    );
+    const idToken = new IDToken(null, await createIDTokenPayload(verifiedAuthorizationRequest, responseOpts), responseOpts);
     if (verifyOpts) {
       await idToken.verify(verifyOpts);
     }

--- a/src/types/SIOP.types.ts
+++ b/src/types/SIOP.types.ts
@@ -132,7 +132,7 @@ export interface AuthorizationResponsePayload {
   token_type?: string;
   refresh_token?: string;
   expires_in?: number;
-  state: string;
+  state?: string;
   id_token?: string;
   vp_token?: W3CVerifiablePresentation | W3CVerifiablePresentation[];
   presentation_submission?: PresentationSubmission;


### PR DESCRIPTION
Some small adjustments to align the implementation with OpenID.Core and SIOP v2 Draft 11. Namely:
- Allow the `state` property to be omitted from the request. This is a recommended property, but not required. It now includes the state in the response when it was present in the request
- Update the IDToken method to extract the client metadata from verified authorization request, so we don't have to deal with registration (draft 11) and client_metadata (draft 11).

All tests pass, and we have tested this to work with a custom SIOPv2 Draft 11 implementation (as requester), and this lib as the responder.