### PR TITLE
fix: parse scheme with number

### DIFF
--- a/src/authorization-request/URI.ts
+++ b/src/authorization-request/URI.ts
@@ -229,7 +229,7 @@ export class URI implements AuthorizationRequestURI {
       throw Error(SIOPErrors.BAD_PARAMS);
     }
     // We strip the uri scheme before passing it to the decode function
-    const scheme: string = uri.match(/^([a-zA-Z-_]+:\/\/)/g)[0];
+    const scheme: string = uri.match(/^([a-zA-Z][a-zA-Z0-9-_]*:\/\/)/g)[0];
     const authorizationRequestPayload = decodeUriAsJson(uri) as AuthorizationRequestPayload;
     return { scheme, authorizationRequestPayload };
   }

--- a/src/helpers/Encodings.ts
+++ b/src/helpers/Encodings.ts
@@ -8,7 +8,7 @@ export function decodeUriAsJson(uri: string) {
   if (!uri) {
     throw new Error(SIOPErrors.BAD_PARAMS);
   }
-  const queryString = uri.replace(/^([a-zA-Z-_]+:\/\/[?]?)/g, '');
+  const queryString = uri.replace(/^([a-zA-Z][a-zA-Z0-9-_]*:\/\/[?]?)/g, '');
   if (!queryString) {
     throw new Error(SIOPErrors.BAD_PARAMS);
   }


### PR DESCRIPTION
Allows to parse schemes with numbers (e.g. `openid4vp://`).

Was causing a few issues. 

Made the regex a bit more complex, as the first chracater is techincally only allowed to be alpha character, and the following can also be digit and a few other characters