### PR TITLE
chore: some changes for JFF interop

### DIFF
--- a/src/authorization-request/AuthorizationRequest.ts
+++ b/src/authorization-request/AuthorizationRequest.ts
@@ -156,6 +156,10 @@ export class AuthorizationRequest {
       // TODO: We need to do something with the metadata probably
     }
     await checkWellknownDIDFromRequest(mergedPayload, opts);
+
+    // TODO: we need to verify somewhere that if response_mode is direct_post, that the response_uri may be present,
+    // BUT not both redirect_uri and response_uri. What is the best place to do this?
+
     const presentationDefinitions = await PresentationExchange.findValidPresentationDefinitions(mergedPayload, await this.getSupportedVersion());
     return {
       ...verifiedJwt,

--- a/src/authorization-response/AuthorizationResponse.ts
+++ b/src/authorization-response/AuthorizationResponse.ts
@@ -3,10 +3,10 @@ import { assertValidVerifyAuthorizationRequestOpts } from '../authorization-requ
 import { IDToken } from '../id-token';
 import { AuthorizationResponsePayload, ResponseType, SIOPErrors, VerifiedAuthorizationRequest, VerifiedAuthorizationResponse } from '../types';
 
-import { assertValidVerifiablePresentations, extractPresentationsFromAuthorizationResponse, verifyPresentations } from './OpenID4VP';
+import { verifyPresentations } from './OpenID4VP';
 import { assertValidResponseOpts } from './Opts';
 import { createResponsePayload } from './Payload';
-import { AuthorizationResponseOpts, PresentationDefinitionWithLocation, VerifyAuthorizationResponseOpts } from './types';
+import { AuthorizationResponseOpts, VerifyAuthorizationResponseOpts } from './types';
 
 export class AuthorizationResponse {
   private readonly _authorizationRequest?: AuthorizationRequest | undefined;
@@ -84,7 +84,8 @@ export class AuthorizationResponse {
   static async fromVerifiedAuthorizationRequest(
     verifiedAuthorizationRequest: VerifiedAuthorizationRequest,
     responseOpts: AuthorizationResponseOpts,
-    verifyOpts: VerifyAuthorizationRequestOpts
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _verifyOpts: VerifyAuthorizationRequestOpts
   ): Promise<AuthorizationResponse> {
     assertValidResponseOpts(responseOpts);
     if (!verifiedAuthorizationRequest) {
@@ -95,9 +96,9 @@ export class AuthorizationResponse {
 
     // const merged = verifiedAuthorizationRequest.authorizationRequest.requestObject, verifiedAuthorizationRequest.requestObject);
     // const presentationDefinitions = await PresentationExchange.findValidPresentationDefinitions(merged, await authorizationRequest.getSupportedVersion());
-    const presentationDefinitions = JSON.parse(
-      JSON.stringify(verifiedAuthorizationRequest.presentationDefinitions)
-    ) as PresentationDefinitionWithLocation[];
+    // const presentationDefinitions = JSON.parse(
+    //   JSON.stringify(verifiedAuthorizationRequest.presentationDefinitions)
+    // ) as PresentationDefinitionWithLocation[];
     const wantsIdToken = await authorizationRequest.containsResponseType(ResponseType.ID_TOKEN);
     // const hasVpToken = await authorizationRequest.containsResponseType(ResponseType.VP_TOKEN);
 
@@ -111,14 +112,18 @@ export class AuthorizationResponse {
       authorizationRequest,
     });
 
-    const wrappedPresentations = await extractPresentationsFromAuthorizationResponse(response);
+    // const wrappedPresentations = await extractPresentationsFromAuthorizationResponse(response);
 
-    await assertValidVerifiablePresentations({
-      presentationDefinitions,
-      presentations: wrappedPresentations,
-      verificationCallback: verifyOpts.verification.presentationVerificationCallback,
-      opts: { ...responseOpts.presentationExchange },
-    });
+    // FIXME: https://github.com/Sphereon-Opensource/SIOP-OID4VP/issues/62
+    console.warn(
+      'Not verifying definition against presentations as multiple VPs for a single definition are not supported yet. See https://github.com/Sphereon-Opensource/SIOP-OID4VP/issues/62'
+    );
+    // await assertValidVerifiablePresentations({
+    //   presentationDefinitions,
+    //   presentations: wrappedPresentations,
+    //   verificationCallback: verifyOpts.verification.presentationVerificationCallback,
+    //   opts: { ...responseOpts.presentationExchange },
+    // });
 
     return response;
   }

--- a/src/authorization-response/types.ts
+++ b/src/authorization-response/types.ts
@@ -20,6 +20,7 @@ import { AuthorizationResponse } from './AuthorizationResponse';
 
 export interface AuthorizationResponseOpts {
   redirectUri?: string; // It's typically comes from the request opts as a measure to prevent hijacking.
+  responseUri?: string; // Alternative to the redirectUri, used when response_mode is `direct_post`
   registration?: ResponseRegistrationOpts;
   checkLinkedDomain?: CheckLinkedDomain;
 
@@ -107,7 +108,8 @@ export interface VerifyAuthorizationResponseOpts {
 }
 
 export interface AuthorizationResponseWithCorrelationId {
-  redirectURI: string;
+  // The URI to send the response to. Can be derived from either the redirect_uri or the response_uri
+  responseURI: string;
   response: AuthorizationResponse;
   correlationId: string;
 }

--- a/src/helpers/Encodings.ts
+++ b/src/helpers/Encodings.ts
@@ -8,7 +8,7 @@ export function decodeUriAsJson(uri: string) {
   if (!uri) {
     throw new Error(SIOPErrors.BAD_PARAMS);
   }
-  const queryString = uri.replace(/^([a-zA-Z][a-zA-Z0-9-_]*:\/\/[?]?)/g, '');
+  const queryString = uri.replace(/^([a-zA-Z][a-zA-Z0-9-_]*:\/\/[a-zA-Z0-9-_%:@\.~!$&'()*+,;=]*[?]?)/, '');
   if (!queryString) {
     throw new Error(SIOPErrors.BAD_PARAMS);
   }

--- a/src/op/OP.ts
+++ b/src/op/OP.ts
@@ -189,7 +189,7 @@ export class OP {
     if (!responseUri) {
       throw Error('No response URI present');
     }
-    const authResponseAsURI = encodeJsonAsURI(payload, ['presentation_submission']);
+    const authResponseAsURI = encodeJsonAsURI(payload, ['presentation_submission', 'vp_token']);
     return post(responseUri, authResponseAsURI, { contentType: ContentType.FORM_URL_ENCODED })
       .then((result: SIOPResonse<unknown>) => {
         this.emitEvent(AuthorizationEvents.ON_AUTH_RESPONSE_SENT_SUCCESS, { correlationId, subject: response });

--- a/src/op/OP.ts
+++ b/src/op/OP.ts
@@ -189,7 +189,7 @@ export class OP {
     if (!responseUri) {
       throw Error('No response URI present');
     }
-    const authResponseAsURI = encodeJsonAsURI(payload);
+    const authResponseAsURI = encodeJsonAsURI(payload, ['presentation_submission']);
     return post(responseUri, authResponseAsURI, { contentType: ContentType.FORM_URL_ENCODED })
       .then((result: SIOPResonse<unknown>) => {
         this.emitEvent(AuthorizationEvents.ON_AUTH_RESPONSE_SENT_SUCCESS, { correlationId, subject: response });

--- a/src/request-object/RequestObject.ts
+++ b/src/request-object/RequestObject.ts
@@ -65,6 +65,9 @@ export class RequestObject {
 
   public async toJwt(): Promise<RequestObjectJwt | undefined> {
     if (!this.jwt) {
+      if (!this.opts && !this.payload) {
+        return undefined;
+      }
       if (!this.opts) {
         throw Error(SIOPErrors.BAD_PARAMS);
       } else if (!this.payload) {

--- a/src/schemas/AuthorizationRequestPayloadVD11.schema.ts
+++ b/src/schemas/AuthorizationRequestPayloadVD11.schema.ts
@@ -330,7 +330,8 @@ export const AuthorizationRequestPayloadVD11SchemaObj = {
         "fragment",
         "form_post",
         "post",
-        "query"
+        "query",
+        "direct_post"
       ]
     },
     "ClaimPayloadCommon": {

--- a/src/schemas/AuthorizationRequestPayloadVID1.schema.ts
+++ b/src/schemas/AuthorizationRequestPayloadVID1.schema.ts
@@ -302,7 +302,8 @@ export const AuthorizationRequestPayloadVID1SchemaObj = {
         "fragment",
         "form_post",
         "post",
-        "query"
+        "query",
+        "direct_post"
       ]
     },
     "ClaimPayloadVID1": {

--- a/src/schemas/AuthorizationResponseOpts.schema.ts
+++ b/src/schemas/AuthorizationResponseOpts.schema.ts
@@ -9,6 +9,9 @@ export const AuthorizationResponseOptsSchemaObj = {
         "redirectUri": {
           "type": "string"
         },
+        "responseUri": {
+          "type": "string"
+        },
         "registration": {
           "$ref": "#/definitions/ResponseRegistrationOpts"
         },
@@ -1349,7 +1352,8 @@ export const AuthorizationResponseOptsSchemaObj = {
         "fragment",
         "form_post",
         "post",
-        "query"
+        "query",
+        "direct_post"
       ]
     },
     "GrantType": {

--- a/src/schemas/DiscoveryMetadataPayload.schema.ts
+++ b/src/schemas/DiscoveryMetadataPayload.schema.ts
@@ -1195,7 +1195,8 @@ export const DiscoveryMetadataPayloadSchemaObj = {
         "fragment",
         "form_post",
         "post",
-        "query"
+        "query",
+        "direct_post"
       ]
     },
     "GrantType": {

--- a/src/types/SIOP.types.ts
+++ b/src/types/SIOP.types.ts
@@ -571,6 +571,10 @@ export enum ResponseMode {
   FORM_POST = 'form_post',
   POST = 'post', // Used in the spec <= version 17
   QUERY = 'query',
+
+  // Defined in openid4vp
+  // See https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-response-mode-direct_post
+  DIRECT_POST = 'direct_post',
 }
 
 export enum ProtocolFlow {

--- a/test/functions/Encodings.spec.ts
+++ b/test/functions/Encodings.spec.ts
@@ -4,7 +4,7 @@ describe('Encodings', () => {
   test('encodeAsUriValue', () => {
     expect(encodeAsUriValue(undefined, { a: { b: { c: 'd', e: 'f' } } })).toBe('a[b][c]=d&a[b][e]=f');
 
-    expect(encodeAsUriValue(undefined, { a: ['b', 'c', 'd'] })).toBe('a=b&a=c&a=d');
+    expect(encodeAsUriValue(undefined, { a: ['b', 'c', 'd'] })).toBe('a[0]=b&a[1]=c&a[2]=d');
 
     expect(
       encodeAsUriValue(undefined, {
@@ -15,14 +15,6 @@ describe('Encodings', () => {
             },
           },
         },
-      })
-    ).toBe('a[b][a%24s939very-2eweird-%3D%3Dkey][c]=d');
-
-    expect(
-      encodeAsUriValue(undefined, {
-        id: 'OzDKp_BFK0WBFrQ1ATKUH',
-        definition_id: 'b88f6449-c515-4642-86a5-faaa72f3be0c',
-        descriptor_map: [{ id: 'OpenBadgeCredential', format: 'jwt_vc', path: '$.verifiableCredential[0]' }],
       })
     ).toBe('a[b][a%24s939very-2eweird-%3D%3Dkey][c]=d');
   });

--- a/test/functions/Encodings.spec.ts
+++ b/test/functions/Encodings.spec.ts
@@ -2,9 +2,9 @@ import { encodeAsUriValue, encodeJsonAsURI } from '../../src';
 
 describe('Encodings', () => {
   test('encodeAsUriValue', () => {
-    expect(encodeAsUriValue(undefined, { a: { b: { c: 'd', e: 'f' } } })).toBe('a[b][c]=d&a[b][e]=f');
+    expect(encodeAsUriValue(undefined, { a: { b: { c: 'd', e: 'f' } } })).toBe('a%5Bb%5D%5Bc%5D=d&a%5Bb%5D%5Be%5D=f');
 
-    expect(encodeAsUriValue(undefined, { a: ['b', 'c', 'd'] })).toBe('a[0]=b&a[1]=c&a[2]=d');
+    expect(encodeAsUriValue(undefined, { a: ['b', 'c', 'd'] })).toBe('a%5B0%5D=b&a%5B1%5D=c&a%5B2%5D=d');
 
     expect(
       encodeAsUriValue(undefined, {
@@ -16,7 +16,7 @@ describe('Encodings', () => {
           },
         },
       })
-    ).toBe('a[b][a%24s939very-2eweird-%3D%3Dkey][c]=d');
+    ).toBe('a%5Bb%5D%5Ba%24s939very-2eweird-%3D%3Dkey%5D%5Bc%5D=d');
   });
 
   test('encodeJsonAsURI', () => {

--- a/test/functions/Encodings.spec.ts
+++ b/test/functions/Encodings.spec.ts
@@ -38,8 +38,10 @@ describe('Encodings', () => {
             },
           ],
         },
+        vp_token: ['ey...1', 'ey...2'],
+        vp_token_single: 'ey...3',
       },
-      ['presentation_submission']
+      ['presentation_submission', 'vp_token', 'vp_token_single']
     );
 
     expect(encoded).toBe(

--- a/test/functions/Encodings.spec.ts
+++ b/test/functions/Encodings.spec.ts
@@ -1,0 +1,57 @@
+import { encodeAsUriValue, encodeJsonAsURI } from '../../src';
+
+describe('Encodings', () => {
+  test('encodeAsUriValue', () => {
+    expect(encodeAsUriValue(undefined, { a: { b: { c: 'd', e: 'f' } } })).toBe('a[b][c]=d&a[b][e]=f');
+
+    expect(encodeAsUriValue(undefined, { a: ['b', 'c', 'd'] })).toBe('a=b&a=c&a=d');
+
+    expect(
+      encodeAsUriValue(undefined, {
+        a: {
+          b: {
+            'a$s939very-2eweird-==key': {
+              c: 'd',
+            },
+          },
+        },
+      })
+    ).toBe('a[b][a%24s939very-2eweird-%3D%3Dkey][c]=d');
+
+    expect(
+      encodeAsUriValue(undefined, {
+        id: 'OzDKp_BFK0WBFrQ1ATKUH',
+        definition_id: 'b88f6449-c515-4642-86a5-faaa72f3be0c',
+        descriptor_map: [{ id: 'OpenBadgeCredential', format: 'jwt_vc', path: '$.verifiableCredential[0]' }],
+      })
+    ).toBe('a[b][a%24s939very-2eweird-%3D%3Dkey][c]=d');
+  });
+
+  test('encodeJsonAsURI', () => {
+    const encoded = encodeJsonAsURI(
+      {
+        presentation_submission: {
+          id: 'bbYJTQe7YPvVx-3rLl4Aq',
+          definition_id: '000fc41b-2859-4fc3-b797-510492a9479a',
+          descriptor_map: [
+            {
+              id: 'OpenBadgeCredential',
+              format: 'jwt_vp',
+              path: '$',
+              path_nested: {
+                id: 'OpenBadgeCredential',
+                format: 'jwt_vc_json',
+                path: '$.vp.verifiableCredential[0]',
+              },
+            },
+          ],
+        },
+      },
+      ['presentation_submission']
+    );
+
+    expect(encoded).toBe(
+      `presentation_submission=id%3DbbYJTQe7YPvVx-3rLl4Aq%26definition_id%3D000fc41b-2859-4fc3-b797-510492a9479a%26descriptor_map%255B0%255D%255Bid%255D%3DOpenBadgeCredential%26descriptor_map%255B0%255D%255Bformat%255D%3Djwt_vp%26descriptor_map%255B0%255D%255Bpath%255D%3D%2524%26descriptor_map%255B0%255D%255Bpath_nested%255D%255Bid%255D%3DOpenBadgeCredential%26descriptor_map%255B0%255D%255Bpath_nested%255D%255Bformat%255D%3Djwt_vc_json%26descriptor_map%255B0%255D%255Bpath_nested%255D%255Bpath%255D%3D%2524.vp.verifiableCredential%255B0%255D`
+    );
+  });
+});


### PR DESCRIPTION
Have been tinkering a bit to get interop with MATTR launchpad.

It  now seems to get stuck on the presentation definition validation, so will have to look at the PEX library for that.

Not sure if the JWT verification bypass is 'ok'. If there's no JWT I think it would be fine to just not validate it, but if there is one, it is validated.

Not ready to be merged, but if you do take a look, maybe these changes can  be of help for getting the sphereon wallet working...
