### PR TITLE
feat: initial sd-jwt support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "qs": "^6.11.2",
     "@sphereon/pex": "2.2.2",
     "@sphereon/pex-models": "^2.1.2",
-    "@sphereon/ssi-types": "^0.17.5",
+    "@sphereon/ssi-types": "^0.17.6-unstable.69",
     "@sphereon/wellknown-dids-client": "^0.1.3",
     "@astronautlabs/jsonpath": "^1.1.2",
     "sha.js": "^2.4.11",

--- a/src/authorization-request/types.ts
+++ b/src/authorization-request/types.ts
@@ -1,3 +1,5 @@
+import { Hasher } from '@sphereon/ssi-types';
+
 import { PresentationDefinitionPayloadOpts } from '../authorization-response';
 import { RequestObjectOpts } from '../request-object';
 import {
@@ -77,6 +79,8 @@ export interface VerifyAuthorizationRequestOpts {
   state?: string; // If provided the state in the request needs to match
 
   supportedVersions?: SupportedVersion[];
+
+  hasher?: Hasher;
 }
 
 /**

--- a/src/authorization-response/AuthorizationResponse.ts
+++ b/src/authorization-response/AuthorizationResponse.ts
@@ -111,13 +111,13 @@ export class AuthorizationResponse {
       authorizationRequest,
     });
 
-    const wrappedPresentations = await extractPresentationsFromAuthorizationResponse(response);
+    const wrappedPresentations = await extractPresentationsFromAuthorizationResponse(response, { hasher: verifyOpts.hasher });
 
     await assertValidVerifiablePresentations({
       presentationDefinitions,
       presentations: wrappedPresentations,
       verificationCallback: verifyOpts.verification.presentationVerificationCallback,
-      opts: { ...responseOpts.presentationExchange },
+      opts: { ...responseOpts.presentationExchange, hasher: verifyOpts.hasher },
     });
 
     return response;

--- a/src/authorization-response/types.ts
+++ b/src/authorization-response/types.ts
@@ -1,6 +1,6 @@
 import { IPresentationDefinition, PresentationSignCallBackParams } from '@sphereon/pex';
 import { Format } from '@sphereon/pex-models';
-import { PresentationSubmission, W3CVerifiablePresentation } from '@sphereon/ssi-types';
+import { CompactSdJwtVc, Hasher, PresentationSubmission, W3CVerifiablePresentation } from '@sphereon/ssi-types';
 
 import {
   CheckLinkedDomain,
@@ -48,7 +48,7 @@ export interface PresentationExchangeResponseOpts {
     selectedCredentials: W3CVerifiableCredential[]
   }[],*/
 
-  verifiablePresentations: W3CVerifiablePresentation[];
+  verifiablePresentations: Array<W3CVerifiablePresentation | CompactSdJwtVc>;
   vpTokenLocation?: VPTokenLocation;
   presentationSubmission?: PresentationSubmission;
   restrictToFormats?: Format;
@@ -96,6 +96,7 @@ export type PresentationSignCallback = (args: PresentationSignCallBackParams) =>
 export interface VerifyAuthorizationResponseOpts {
   correlationId: string;
   verification: InternalVerification | ExternalVerification;
+  hasher?: Hasher;
   // didDocument?: DIDDocument; // If not provided the DID document will be resolved from the request
   nonce?: string; // To verify the response against the supplied nonce
   state?: string; // To verify the response against the supplied state

--- a/src/helpers/Revocation.ts
+++ b/src/helpers/Revocation.ts
@@ -1,4 +1,4 @@
-import { W3CVerifiableCredential, WrappedVerifiablePresentation } from '@sphereon/ssi-types';
+import { CredentialMapper, W3CVerifiableCredential, WrappedVerifiableCredential, WrappedVerifiablePresentation } from '@sphereon/ssi-types';
 
 import { RevocationStatus, RevocationVerification, RevocationVerificationCallback, VerifiableCredentialTypeFormat } from '../types';
 
@@ -14,21 +14,45 @@ export const verifyRevocation = async (
     throw new Error(`Revocation callback not provided`);
   }
 
-  const vcs = Array.isArray(vpToken.presentation.verifiableCredential)
-    ? vpToken.presentation.verifiableCredential
-    : [vpToken.presentation.verifiableCredential];
+  const vcs = CredentialMapper.isWrappedSdJwtVerifiablePresentation(vpToken) ? [vpToken.vcs[0]] : vpToken.presentation.verifiableCredential;
   for (const vc of vcs) {
+    vc.format;
     if (
       revocationVerification === RevocationVerification.ALWAYS ||
-      (revocationVerification === RevocationVerification.IF_PRESENT && vc.credential.credentialStatus)
+      (revocationVerification === RevocationVerification.IF_PRESENT && credentialHasStatus(vc))
     ) {
       const result = await revocationVerificationCallback(
         vc.original as W3CVerifiableCredential,
-        vc.format.toLowerCase().includes('jwt') ? VerifiableCredentialTypeFormat.JWT_VC : VerifiableCredentialTypeFormat.LDP_VC
+        originalTypeToVerifiableCredentialTypeFormat(vc.format)
       );
       if (result.status === RevocationStatus.INVALID) {
-        throw new Error(`Revocation invalid for vc: ${vc.credential.id}. Error: ${result.error}`);
+        throw new Error(`Revocation invalid for vc. Error: ${result.error}`);
       }
     }
   }
 };
+
+function originalTypeToVerifiableCredentialTypeFormat(original: WrappedVerifiableCredential['format']): VerifiableCredentialTypeFormat {
+  const mapping: { [T in WrappedVerifiableCredential['format']]: VerifiableCredentialTypeFormat } = {
+    'vc+sd-jwt': VerifiableCredentialTypeFormat.SD_JWT_VC,
+    jwt: VerifiableCredentialTypeFormat.JWT_VC,
+    jwt_vc: VerifiableCredentialTypeFormat.JWT_VC,
+    ldp: VerifiableCredentialTypeFormat.LDP_VC,
+    ldp_vc: VerifiableCredentialTypeFormat.LDP_VC,
+  };
+
+  return mapping[original];
+}
+
+/**
+ * Checks whether a wrapped verifiable credential has a status in the credential.
+ * For w3c credentials it will check the presence of `credentialStatus` property
+ * For SD-JWT it will check the presence of `status` property
+ */
+function credentialHasStatus(wrappedVerifiableCredential: WrappedVerifiableCredential) {
+  if (CredentialMapper.isWrappedSdJwtVerifiableCredential(wrappedVerifiableCredential)) {
+    return wrappedVerifiableCredential.decoded.status !== undefined;
+  } else {
+    return wrappedVerifiableCredential.credential.credentialStatus !== undefined;
+  }
+}

--- a/src/op/OP.ts
+++ b/src/op/OP.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-import { IIssuerId } from '@sphereon/ssi-types/src/types/vc';
+import { IIssuerId } from '@sphereon/ssi-types/dist/types/w3c-vc';
 import { v4 as uuidv4 } from 'uuid';
 
 import { AuthorizationRequest, URI, VerifyAuthorizationRequestOpts } from '../authorization-request';

--- a/src/op/OPBuilder.ts
+++ b/src/op/OPBuilder.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import { Config, getUniResolver, UniResolver } from '@sphereon/did-uni-client';
-import { IIssuerId } from '@sphereon/ssi-types';
+import { Hasher, IIssuerId } from '@sphereon/ssi-types';
 import { VerifyCallback } from '@sphereon/wellknown-dids-client';
 import { Signer } from 'did-jwt';
 import { Resolvable, Resolver } from 'did-resolver';
@@ -39,12 +39,20 @@ export class OPBuilder {
   supportedVersions?: SupportedVersion[];
   eventEmitter?: EventEmitter;
 
+  hasher?: Hasher;
+
   addDidMethod(didMethod: string, opts?: { resolveUrl?: string; baseUrl?: string }): OPBuilder {
     const method = didMethod.startsWith('did:') ? getMethodFromDid(didMethod) : didMethod;
     if (method === SubjectSyntaxTypesSupportedValues.DID.valueOf()) {
       opts ? this.addResolver('', new UniResolver({ ...opts } as Config)) : this.addResolver('', null);
     }
     opts ? this.addResolver(method, new Resolver(getUniResolver(method, { ...opts }))) : this.addResolver(method, null);
+    return this;
+  }
+
+  withHasher(hasher: Hasher): OPBuilder {
+    this.hasher = hasher;
+
     return this;
   }
 

--- a/src/op/Opts.ts
+++ b/src/op/Opts.ts
@@ -85,6 +85,7 @@ export const createVerifyRequestOptsFromBuilderOrExistingOpts = (opts: {
   }
   return opts.builder
     ? {
+        hasher: opts.builder.hasher,
         verification: {
           mode: VerificationMode.INTERNAL,
           checkLinkedDomain: opts.builder.checkLinkedDomain,

--- a/src/rp/Opts.ts
+++ b/src/rp/Opts.ts
@@ -62,6 +62,7 @@ export const createVerifyResponseOptsFromBuilderOrExistingOpts = (opts: { builde
   }
   return opts.builder
     ? {
+        hasher: opts.builder.hasher,
         verification: {
           mode: VerificationMode.INTERNAL,
           checkLinkedDomain: opts.builder.checkLinkedDomain,

--- a/src/rp/RPBuilder.ts
+++ b/src/rp/RPBuilder.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import { Config, getUniResolver, UniResolver } from '@sphereon/did-uni-client';
 import { IPresentationDefinition } from '@sphereon/pex';
+import { Hasher } from '@sphereon/ssi-types';
 import { VerifyCallback } from '@sphereon/wellknown-dids-client';
 import { Signer } from 'did-jwt';
 import { Resolvable, Resolver } from 'did-resolver';
@@ -54,6 +55,8 @@ export class RPBuilder {
   clientMetadata?: ClientMetadataOpts = undefined;
   clientId: string;
 
+  hasher: Hasher;
+
   private constructor(supportedRequestVersion?: SupportedVersion) {
     if (supportedRequestVersion) {
       this.addSupportedVersion(supportedRequestVersion);
@@ -70,6 +73,12 @@ export class RPBuilder {
     const propertyValue = Array.isArray(responseType) ? responseType.join(' ').trim() : responseType;
     this._authorizationRequestPayload.response_type = assignIfAuth({ propertyValue, targets }, false);
     this._requestObjectPayload.response_type = assignIfRequestObject({ propertyValue, targets }, true);
+    return this;
+  }
+
+  withHasher(hasher: Hasher): RPBuilder {
+    this.hasher = hasher;
+
     return this;
   }
 

--- a/src/schemas/AuthorizationResponseOpts.schema.ts
+++ b/src/schemas/AuthorizationResponseOpts.schema.ts
@@ -1613,7 +1613,14 @@ export const AuthorizationResponseOptsSchemaObj = {
         "verifiablePresentations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/W3CVerifiablePresentation"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/W3CVerifiablePresentation"
+              },
+              {
+                "$ref": "#/definitions/CompactSdJwtVc"
+              }
+            ]
           }
         },
         "vpTokenLocation": {
@@ -1646,7 +1653,7 @@ export const AuthorizationResponseOptsSchemaObj = {
           "$ref": "#/definitions/CompactJWT"
         }
       ],
-      "description": "Represents a signed Verifiable Presentation (includes proof), in either JSON or compact JWT format. See  {@link  https://www.w3.org/TR/vc-data-model/#presentations | VC data model } \nSee  {@link  https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+      "description": "Represents a signed Verifiable Presentation (includes proof), in either JSON or compact JWT format. See  {@link  https://www.w3.org/TR/vc-data-model/#presentations VC data model }  See  {@link  https://www.w3.org/TR/vc-data-model/#proof-formats proof formats }"
     },
     "IVerifiablePresentation": {
       "type": "object",
@@ -1830,7 +1837,7 @@ export const AuthorizationResponseOptsSchemaObj = {
           "$ref": "#/definitions/CompactJWT"
         }
       ],
-      "description": "Represents a signed Verifiable Credential (includes proof), in either JSON or compact JWT format. See  {@link  https://www.w3.org/TR/vc-data-model/#credentials | VC data model } \nSee  {@link  https://www.w3.org/TR/vc-data-model/#proof-formats | proof formats }"
+      "description": "Represents a signed Verifiable Credential (includes proof), in either JSON, compact JWT or compact SD-JWT VC format. See  {@link  https://www.w3.org/TR/vc-data-model/#credentials VC data model }  See  {@link  https://www.w3.org/TR/vc-data-model/#proof-formats proof formats }"
     },
     "IVerifiableCredential": {
       "type": "object",
@@ -2053,6 +2060,10 @@ export const AuthorizationResponseOptsSchemaObj = {
       ],
       "additionalProperties": false,
       "description": "descriptor map laying out the structure of the presentation submission."
+    },
+    "CompactSdJwtVc": {
+      "type": "string",
+      "description": "Represents a selective disclosure JWT vc in compact form."
     },
     "VPTokenLocation": {
       "type": "string",

--- a/src/types/SIOP.types.ts
+++ b/src/types/SIOP.types.ts
@@ -3,6 +3,7 @@
 import { Format, PresentationDefinitionV1, PresentationDefinitionV2 } from '@sphereon/pex-models';
 import {
   AdditionalClaims,
+  CompactSdJwtVc,
   IPresentation,
   IVerifiablePresentation,
   PresentationSubmission,
@@ -155,7 +156,7 @@ export interface AuthorizationResponsePayload {
   expires_in?: number;
   state?: string;
   id_token?: string;
-  vp_token?: W3CVerifiablePresentation | W3CVerifiablePresentation[];
+  vp_token?: Array<W3CVerifiablePresentation | CompactSdJwtVc> | W3CVerifiablePresentation | CompactSdJwtVc;
   presentation_submission?: PresentationSubmission;
   verifiedData?: IPresentation | AdditionalClaims;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -457,11 +458,13 @@ export interface ClientMetadataProperties extends ObjectBy {
 export enum VerifiablePresentationTypeFormat {
   JWT_VP = 'jwt_vp',
   LDP_VP = 'ldp_vp',
+  SD_JWT_VC = 'vc+sd-jwt',
 }
 
 export enum VerifiableCredentialTypeFormat {
   LDP_VC = 'ldp_vc',
   JWT_VC = 'jwt_vc',
+  SD_JWT_VC = 'vc+sd-jwt',
 }
 
 export enum EncSymmetricAlgorithmCode {

--- a/test/AuthenticationResponse.response.spec.ts
+++ b/test/AuthenticationResponse.response.spec.ts
@@ -1,5 +1,5 @@
 import { IPresentationDefinition } from '@sphereon/pex';
-import { ICredential, IProofType, IVerifiableCredential, IVerifiablePresentation } from '@sphereon/ssi-types';
+import { ICredential, IPresentation, IProofType, IVerifiableCredential, IVerifiablePresentation } from '@sphereon/ssi-types';
 import { IVerifyCallbackArgs, IVerifyCredentialResult } from '@sphereon/wellknown-dids-client';
 
 import {
@@ -299,7 +299,7 @@ describe('create JWT from Request JWT should', () => {
     const mockReqEntity = await mockedGetEnterpriseAuthToken('REQ COMPANY');
     const mockResEntity = await mockedGetEnterpriseAuthToken('RES COMPANY');
     const presentationSignCallback: PresentationSignCallback = async (_args) => ({
-      ..._args.presentation,
+      ...(_args.presentation as IPresentation),
       proof: {
         type: 'RsaSignature2018',
         created: '2018-09-14T21:19:10Z',
@@ -573,7 +573,7 @@ describe('create JWT from Request JWT should', () => {
     });
     await pex.selectVerifiableCredentialsForSubmission(definition);
     const presentationSignCallback: PresentationSignCallback = async (_args) => ({
-      ..._args.presentation,
+      ...(_args.presentation as IPresentation),
       proof: {
         type: 'RsaSignature2018',
         created: '2018-09-14T21:19:10Z',

--- a/test/IT.spec.ts
+++ b/test/IT.spec.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import { IPresentationDefinition } from '@sphereon/pex';
-import { CredentialMapper, IProofType, IVerifiableCredential, W3CVerifiablePresentation } from '@sphereon/ssi-types';
+import { CredentialMapper, IPresentation, IProofType, IVerifiableCredential, W3CVerifiablePresentation } from '@sphereon/ssi-types';
 import { IVerifyCallbackArgs, IVerifyCredentialResult, VerifyCallback, WDCErrors } from '@sphereon/wellknown-dids-client';
 import nock from 'nock';
 
@@ -48,7 +48,7 @@ const EXAMPLE_REFERENCE_URL = 'https://rp.acme.com/siop/jwts';
 const HOLDER_DID = 'did:example:ebfeb1f712ebc6f1c276e12ec21';
 
 const presentationSignCallback: PresentationSignCallback = async (_args) => ({
-  ..._args.presentation,
+  ...(_args.presentation as IPresentation),
   proof: {
     type: 'RsaSignature2018',
     created: '2018-09-14T21:19:10Z',
@@ -105,7 +105,7 @@ function getVCs(): IVerifiableCredential[] {
     {
       identifier: '83627465',
       name: 'Permanent Resident Card',
-      type: ['PermanentResidentCard', 'verifiableCredential'],
+      type: ['PermanentResidentCard', 'VerifiableCredential'],
       id: 'https://issuer.oidp.uscis.gov/credentials/83627465dsdsdsd',
       credentialSubject: {
         birthCountry: 'Bahamas',
@@ -443,125 +443,133 @@ describe('RP and OP interaction should', () => {
   });
 
   it('succeed when calling with presentation definitions and right verifiable presentation', async () => {
-    const rpMockEntity = {
-      hexPrivateKey: '2bbd6a78be9ab2193bcf74aa6d39ab59c1d1e2f7e9ef899a38fb4d94d8aa90e2',
-      did: 'did:ethr:goerli:0x038f8d21b0446c46b05aecdc603f73831578e28857adba14de569f31f3e569c024',
-      didKey: 'did:ethr:goerli:0x038f8d21b0446c46b05aecdc603f73831578e28857adba14de569f31f3e569c024#controllerKey',
-    };
+    try {
+      const rpMockEntity = {
+        hexPrivateKey: '2bbd6a78be9ab2193bcf74aa6d39ab59c1d1e2f7e9ef899a38fb4d94d8aa90e2',
+        did: 'did:ethr:goerli:0x038f8d21b0446c46b05aecdc603f73831578e28857adba14de569f31f3e569c024',
+        didKey: 'did:ethr:goerli:0x038f8d21b0446c46b05aecdc603f73831578e28857adba14de569f31f3e569c024#controllerKey',
+      };
 
-    const opMockEntity = {
-      hexPrivateKey: '73d24dd0fb69abdc12e7a99d8f9a970fdc8ad90598cc64cff35b584220ace0c8',
-      did: 'did:ethr:goerli:0x03a1370d4dd249eabb23245aeb4aec988fbca598ff83db59144d89b3835371daca',
-      didKey: 'did:ethr:goerli:0x03a1370d4dd249eabb23245aeb4aec988fbca598ff83db59144d89b3835371daca#controllerKey',
-    };
+      const opMockEntity = {
+        hexPrivateKey: '73d24dd0fb69abdc12e7a99d8f9a970fdc8ad90598cc64cff35b584220ace0c8',
+        did: 'did:ethr:goerli:0x03a1370d4dd249eabb23245aeb4aec988fbca598ff83db59144d89b3835371daca',
+        didKey: 'did:ethr:goerli:0x03a1370d4dd249eabb23245aeb4aec988fbca598ff83db59144d89b3835371daca#controllerKey',
+      };
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const verifyCallback = async (_args: IVerifyCallbackArgs): Promise<IVerifyCredentialResult> => ({ verified: true });
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const presentationVerificationCallback: PresentationVerificationCallback = async (_args) => ({ verified: true });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const verifyCallback = async (_args: IVerifyCallbackArgs): Promise<IVerifyCredentialResult> => ({ verified: true });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const presentationVerificationCallback: PresentationVerificationCallback = async (_args) => ({ verified: true });
 
-    const rp = RP.builder({ requestVersion: SupportedVersion.SIOPv2_ID1 })
-      .withClientId(rpMockEntity.did)
-      .withScope('test')
-      .withResponseType([ResponseType.ID_TOKEN, ResponseType.VP_TOKEN])
-      .withRedirectUri(EXAMPLE_REDIRECT_URL)
-      .withPresentationDefinition({ definition: getPresentationDefinition() }, [PropertyTarget.REQUEST_OBJECT, PropertyTarget.AUTHORIZATION_REQUEST])
-      .withPresentationVerification(presentationVerificationCallback)
-      .withWellknownDIDVerifyCallback(verifyCallback)
-      .withRevocationVerification(RevocationVerification.NEVER)
-      .withRequestBy(PassBy.VALUE)
-      .withInternalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey, SigningAlgo.ES256K)
-      .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('ethr')
-      .withClientMetadata({
-        client_id: WELL_KNOWN_OPENID_FEDERATION,
-        idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
-        requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
-        responseTypesSupported: [ResponseType.ID_TOKEN],
-        vpFormatsSupported: { jwt_vc: { alg: [SigningAlgo.EDDSA] } },
-        scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
-        subjectTypesSupported: [SubjectType.PAIRWISE],
-        subject_syntax_types_supported: ['did', 'did:ethr'],
-        passBy: PassBy.VALUE,
-        logo_uri: VERIFIER_LOGO_FOR_CLIENT,
-        clientName: VERIFIER_NAME_FOR_CLIENT,
-        'clientName#nl-NL': VERIFIER_NAME_FOR_CLIENT_NL + '2022100322',
-        clientPurpose: VERIFIERZ_PURPOSE_TO_VERIFY,
-        'clientPurpose#nl-NL': VERIFIERZ_PURPOSE_TO_VERIFY_NL,
-      })
-      .withSupportedVersions(SupportedVersion.SIOPv2_ID1)
-      .build();
-    const op = OP.builder()
-      .withPresentationSignCallback(presentationSignCallback)
-      .withExpiresIn(1000)
-      .withWellknownDIDVerifyCallback(verifyCallback)
-      .addDidMethod('ethr')
-      .withInternalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey, SigningAlgo.ES256K)
-      .withRegistration({
-        authorizationEndpoint: 'www.myauthorizationendpoint.com',
-        idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
-        issuer: ResponseIss.SELF_ISSUED_V2,
-        requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
-        responseTypesSupported: [ResponseType.ID_TOKEN, ResponseType.VP_TOKEN],
-        vpFormats: { jwt_vc: { alg: [SigningAlgo.EDDSA] } },
-        scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
-        subjectTypesSupported: [SubjectType.PAIRWISE],
-        subject_syntax_types_supported: [],
-        passBy: PassBy.VALUE,
-        logo_uri: VERIFIER_LOGO_FOR_CLIENT,
-        clientName: VERIFIER_NAME_FOR_CLIENT,
-        'clientName#nl-NL': VERIFIER_NAME_FOR_CLIENT_NL + '2022100323',
-        clientPurpose: VERIFIERZ_PURPOSE_TO_VERIFY,
-        'clientPurpose#nl-NL': VERIFIERZ_PURPOSE_TO_VERIFY_NL,
-      })
-      .withSupportedVersions(SupportedVersion.SIOPv2_ID1)
-      .build();
+      const rp = RP.builder({ requestVersion: SupportedVersion.SIOPv2_ID1 })
+        .withClientId(rpMockEntity.did)
+        .withScope('test')
+        .withResponseType([ResponseType.ID_TOKEN, ResponseType.VP_TOKEN])
+        .withRedirectUri(EXAMPLE_REDIRECT_URL)
+        .withPresentationDefinition({ definition: getPresentationDefinition() }, [
+          PropertyTarget.REQUEST_OBJECT,
+          PropertyTarget.AUTHORIZATION_REQUEST,
+        ])
+        .withPresentationVerification(presentationVerificationCallback)
+        .withWellknownDIDVerifyCallback(verifyCallback)
+        .withRevocationVerification(RevocationVerification.NEVER)
+        .withRequestBy(PassBy.VALUE)
+        .withInternalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey, SigningAlgo.ES256K)
+        .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
+        .addDidMethod('ethr')
+        .withClientMetadata({
+          client_id: WELL_KNOWN_OPENID_FEDERATION,
+          idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
+          requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
+          responseTypesSupported: [ResponseType.ID_TOKEN],
+          vpFormatsSupported: { jwt_vc: { alg: [SigningAlgo.EDDSA] } },
+          scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
+          subjectTypesSupported: [SubjectType.PAIRWISE],
+          subject_syntax_types_supported: ['did', 'did:ethr'],
+          passBy: PassBy.VALUE,
+          logo_uri: VERIFIER_LOGO_FOR_CLIENT,
+          clientName: VERIFIER_NAME_FOR_CLIENT,
+          'clientName#nl-NL': VERIFIER_NAME_FOR_CLIENT_NL + '2022100322',
+          clientPurpose: VERIFIERZ_PURPOSE_TO_VERIFY,
+          'clientPurpose#nl-NL': VERIFIERZ_PURPOSE_TO_VERIFY_NL,
+        })
+        .withSupportedVersions(SupportedVersion.SIOPv2_ID1)
+        .build();
+      const op = OP.builder()
+        .withPresentationSignCallback(presentationSignCallback)
+        .withExpiresIn(1000)
+        .withWellknownDIDVerifyCallback(verifyCallback)
+        .addDidMethod('ethr')
+        .withInternalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey, SigningAlgo.ES256K)
+        .withRegistration({
+          authorizationEndpoint: 'www.myauthorizationendpoint.com',
+          idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
+          issuer: ResponseIss.SELF_ISSUED_V2,
+          requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
+          responseTypesSupported: [ResponseType.ID_TOKEN, ResponseType.VP_TOKEN],
+          vpFormats: { jwt_vc: { alg: [SigningAlgo.EDDSA] } },
+          scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
+          subjectTypesSupported: [SubjectType.PAIRWISE],
+          subject_syntax_types_supported: [],
+          passBy: PassBy.VALUE,
+          logo_uri: VERIFIER_LOGO_FOR_CLIENT,
+          clientName: VERIFIER_NAME_FOR_CLIENT,
+          'clientName#nl-NL': VERIFIER_NAME_FOR_CLIENT_NL + '2022100323',
+          clientPurpose: VERIFIERZ_PURPOSE_TO_VERIFY,
+          'clientPurpose#nl-NL': VERIFIERZ_PURPOSE_TO_VERIFY_NL,
+        })
+        .withSupportedVersions(SupportedVersion.SIOPv2_ID1)
+        .build();
 
-    const requestURI = await rp.createAuthorizationRequestURI({
-      correlationId: '1234',
-      nonce: 'qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg',
-      state: 'b32f0087fc9816eb813fd11f',
-    });
+      const requestURI = await rp.createAuthorizationRequestURI({
+        correlationId: '1234',
+        nonce: 'qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg',
+        state: 'b32f0087fc9816eb813fd11f',
+      });
 
-    // Let's test the parsing
-    const parsedAuthReqURI = await op.parseAuthorizationRequestURI(requestURI.encodedUri);
-    expect(parsedAuthReqURI.authorizationRequestPayload).toBeDefined();
-    expect(parsedAuthReqURI.requestObjectJwt).toBeDefined();
-    // expect(parsedAuthReqURI.registration).toBeDefined();
+      // Let's test the parsing
+      const parsedAuthReqURI = await op.parseAuthorizationRequestURI(requestURI.encodedUri);
+      expect(parsedAuthReqURI.authorizationRequestPayload).toBeDefined();
+      expect(parsedAuthReqURI.requestObjectJwt).toBeDefined();
+      // expect(parsedAuthReqURI.registration).toBeDefined();
 
-    const verifiedAuthReqWithJWT = await op.verifyAuthorizationRequest(parsedAuthReqURI.requestObjectJwt);
-    expect(verifiedAuthReqWithJWT.signer).toBeDefined();
-    expect(verifiedAuthReqWithJWT.issuer).toMatch(rpMockEntity.did);
-    const pex = new PresentationExchange({ allDIDs: [HOLDER_DID], allVerifiableCredentials: getVCs() });
-    const pd: PresentationDefinitionWithLocation[] = await PresentationExchange.findValidPresentationDefinitions(
-      parsedAuthReqURI.authorizationRequestPayload
-    );
-    await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
-    const verifiablePresentationResult = await pex.createVerifiablePresentation(pd[0].definition, getVCs(), presentationSignCallback, {});
-    const authenticationResponseWithJWT = await op.createAuthorizationResponse(verifiedAuthReqWithJWT, {
-      presentationExchange: {
-        verifiablePresentations: [verifiablePresentationResult.verifiablePresentation],
-        vpTokenLocation: VPTokenLocation.AUTHORIZATION_RESPONSE,
-        presentationSubmission: verifiablePresentationResult.presentationSubmission,
-        /*credentialsAndDefinitions: [
+      const verifiedAuthReqWithJWT = await op.verifyAuthorizationRequest(parsedAuthReqURI.requestObjectJwt);
+      expect(verifiedAuthReqWithJWT.signer).toBeDefined();
+      expect(verifiedAuthReqWithJWT.issuer).toMatch(rpMockEntity.did);
+      const pex = new PresentationExchange({ allDIDs: [HOLDER_DID], allVerifiableCredentials: getVCs() });
+      const pd: PresentationDefinitionWithLocation[] = await PresentationExchange.findValidPresentationDefinitions(
+        parsedAuthReqURI.authorizationRequestPayload
+      );
+      await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
+      const verifiablePresentationResult = await pex.createVerifiablePresentation(pd[0].definition, getVCs(), presentationSignCallback, {});
+      const authenticationResponseWithJWT = await op.createAuthorizationResponse(verifiedAuthReqWithJWT, {
+        presentationExchange: {
+          verifiablePresentations: [verifiablePresentationResult.verifiablePresentation],
+          vpTokenLocation: VPTokenLocation.AUTHORIZATION_RESPONSE,
+          presentationSubmission: verifiablePresentationResult.presentationSubmission,
+          /*credentialsAndDefinitions: [
           {
             presentation: vp,
             format: VerifiablePresentationTypeFormat.LDP_VP,
             vpTokenLocation: VPTokenLocation.AUTHORIZATION_RESPONSE,
           },
         ],*/
-      },
-    });
-    expect(authenticationResponseWithJWT.response.payload).toBeDefined();
-    expect(authenticationResponseWithJWT.response.idToken).toBeDefined();
+        },
+      });
+      expect(authenticationResponseWithJWT.response.payload).toBeDefined();
+      expect(authenticationResponseWithJWT.response.idToken).toBeDefined();
 
-    const verifiedAuthResponseWithJWT = await rp.verifyAuthorizationResponse(authenticationResponseWithJWT.response.payload, {
-      /*audience: EXAMPLE_REDIRECT_URL,*/
-      presentationDefinitions: [{ definition: pd[0].definition, location: pd[0].location }],
-    });
+      const verifiedAuthResponseWithJWT = await rp.verifyAuthorizationResponse(authenticationResponseWithJWT.response.payload, {
+        /*audience: EXAMPLE_REDIRECT_URL,*/
+        presentationDefinitions: [{ definition: pd[0].definition, location: pd[0].location }],
+      });
 
-    expect(verifiedAuthResponseWithJWT.idToken.jwt).toBeDefined();
-    expect(verifiedAuthResponseWithJWT.idToken.payload.nonce).toMatch('qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg');
+      expect(verifiedAuthResponseWithJWT.idToken.jwt).toBeDefined();
+      expect(verifiedAuthResponseWithJWT.idToken.payload.nonce).toMatch('qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg');
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
   });
 
   it(
@@ -1139,7 +1147,7 @@ describe('RP and OP interaction should', () => {
         {
           identifier: '83627465',
           name: 'Permanent Resident Card',
-          type: ['PermanentResidentCard', 'verifiableCredential'],
+          type: ['PermanentResidentCard', 'VerifiableCredential'],
           id: 'https://issuer.oidp.uscis.gov/credentials/83627465dsdsdsd',
           credentialSubject: {
             birthCountry: 'Bahamas',
@@ -1214,7 +1222,7 @@ describe('RP and OP interaction should', () => {
         {
           identifier: '83627465',
           name: 'Permanent Resident Card',
-          type: ['PermanentResidentCard', 'verifiableCredential'],
+          type: ['PermanentResidentCard', 'VerifiableCredential'],
           id: 'https://issuer.oidp.uscis.gov/credentials/83627465dsdsdsd',
           credentialSubject: {
             birthCountry: 'Bahamas',

--- a/test/PresentationExchange.spec.ts
+++ b/test/PresentationExchange.spec.ts
@@ -1,6 +1,6 @@
 import { PresentationDefinitionV1 } from '@sphereon/pex-models';
-import { CredentialMapper, IProofType, IVerifiableCredential } from '@sphereon/ssi-types';
-import { W3CVerifiablePresentation } from '@sphereon/ssi-types/src/types/vc';
+import { CredentialMapper, IPresentation, IProofType, IVerifiableCredential } from '@sphereon/ssi-types';
+import { W3CVerifiablePresentation } from '@sphereon/ssi-types/src/types/w3c-vc';
 import nock from 'nock';
 
 import {
@@ -326,7 +326,7 @@ describe('presentation exchange manager tests', () => {
     );
     await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
     const presentationSignCallback: PresentationSignCallback = async (_args) => ({
-      ..._args.presentation,
+      ...(_args.presentation as IPresentation),
       proof: {
         type: 'RsaSignature2018',
         created: '2018-09-14T21:19:10Z',
@@ -399,7 +399,7 @@ describe('presentation exchange manager tests', () => {
     const pex = new PresentationExchange({ allDIDs: [HOLDER_DID], allVerifiableCredentials: vcs });
     await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
     const presentationSignCallback: PresentationSignCallback = async (_args) => ({
-      ..._args.presentation,
+      ...(_args.presentation as IPresentation),
       proof: {
         type: 'RsaSignature2018',
         created: '2018-09-14T21:19:10Z',

--- a/test/SdJwt.spec.ts
+++ b/test/SdJwt.spec.ts
@@ -1,0 +1,228 @@
+import { createHash } from 'node:crypto';
+
+import { IPresentationDefinition, SdJwtDecodedVerifiableCredentialWithKbJwtInput } from '@sphereon/pex';
+import { OriginalVerifiableCredential } from '@sphereon/ssi-types';
+import { IVerifyCallbackArgs, IVerifyCredentialResult } from '@sphereon/wellknown-dids-client';
+
+import {
+  OP,
+  PassBy,
+  PresentationDefinitionWithLocation,
+  PresentationExchange,
+  PresentationSignCallback,
+  PresentationVerificationCallback,
+  PropertyTarget,
+  ResponseIss,
+  ResponseType,
+  RevocationVerification,
+  RP,
+  Scope,
+  SigningAlgo,
+  SubjectType,
+  SupportedVersion,
+  VPTokenLocation,
+} from '../src';
+
+import { WELL_KNOWN_OPENID_FEDERATION } from './TestUtils';
+import {
+  VERIFIER_LOGO_FOR_CLIENT,
+  VERIFIER_NAME_FOR_CLIENT,
+  VERIFIER_NAME_FOR_CLIENT_NL,
+  VERIFIERZ_PURPOSE_TO_VERIFY,
+  VERIFIERZ_PURPOSE_TO_VERIFY_NL,
+} from './data/mockedData';
+
+const hasher = (data: string) => createHash('sha256').update(data).digest();
+jest.setTimeout(30000);
+
+const EXAMPLE_REDIRECT_URL = 'https://acme.com/hello';
+
+const HOLDER_DID = 'did:example:ebfeb1f712ebc6f1c276e12ec21';
+const SD_JWT_VC =
+  'eyJhbGciOiJFZERTQSIsInR5cCI6InZjK3NkLWp3dCJ9.eyJpYXQiOjE3MDA0NjQ3MzYwNzYsImlzcyI6ImRpZDprZXk6c29tZS1yYW5kb20tZGlkLWtleSIsIm5iZiI6MTcwMDQ2NDczNjE3NiwidmN0IjoiaHR0cHM6Ly9oaWdoLWFzc3VyYW5jZS5jb20vU3RhdGVCdXNpbmVzc0xpY2Vuc2UiLCJ1c2VyIjp7Il9zZCI6WyI5QmhOVDVsSG5QVmpqQUp3TnR0NDIzM216MFVVMUd3RmFmLWVNWkFQV0JNIiwiSVl5d1FQZl8tNE9hY2Z2S2l1cjRlSnFMa1ZleWRxcnQ1Y2UwMGJReWNNZyIsIlNoZWM2TUNLakIxeHlCVl91QUtvLURlS3ZvQllYbUdBd2VGTWFsd05xbUEiLCJXTXpiR3BZYmhZMkdoNU9pWTRHc2hRU1dQREtSeGVPZndaNEhaQW5YS1RZIiwiajZ6ZFg1OUJYZHlTNFFaTGJITWJ0MzJpenRzWXdkZzRjNkpzWUxNc3ZaMCIsInhKR3Radm41cFM4VEhqVFlJZ3MwS1N5VC1uR3BSR3hDVnp6c1ZEbmMyWkUiXX0sImxpY2Vuc2UiOnsibnVtYmVyIjoxMH0sImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJUQ0FFUjE5WnZ1M09IRjRqNFc0dmZTVm9ISVAxSUxpbERsczd2Q2VHZW1jIiwieSI6Ilp4amlXV2JaTVFHSFZXS1ZRNGhiU0lpcnNWZnVlY0NFNnQ0alQ5RjJIWlEifX0sIl9zZF9hbGciOiJzaGEtMjU2IiwiX3NkIjpbIl90YnpMeHBaeDBQVHVzV2hPOHRUZlVYU2ZzQjVlLUtrbzl3dmZaaFJrYVkiLCJ1WmNQaHdUTmN4LXpNQU1zemlYMkFfOXlJTGpQSEhobDhEd2pvVXJLVVdZIl19.HAcudVInhNpXkTPQGNosjKTFRJWgKj90NpfloRaDQchGd4zxc1ChWTCCPXzUXTBypASKrzgjZCiXlTr0bzmLAg~WyJHeDZHRUZvR2t6WUpWLVNRMWlDREdBIiwiZGF0ZU9mQmlydGgiLCIyMDAwMDEwMSJd~WyJ1LUt3cmJvMkZfTExQekdSZE1XLUtBIiwibmFtZSIsIkpvaG4iXQ~WyJNV1ZieGJqVFZxUXdLS3h2UGVZdWlnIiwibGFzdE5hbWUiLCJEb2UiXQ~';
+
+const presentationSignCallback: PresentationSignCallback = async (_args) => {
+  const kbJwt = (_args.presentation as SdJwtDecodedVerifiableCredentialWithKbJwtInput).kbJwt;
+
+  // In real life scenario, the KB-JWT must be signed
+  // As the KB-JWT is a normal JWT, the user does not need an sd-jwt implementation in the presentation sign callback
+  // NOTE: should the presentation just be the KB-JWT header + payload instead of the whole decoded SD JWT?
+  expect(kbJwt).toEqual({
+    header: {
+      typ: 'kb+jwt',
+    },
+    payload: {
+      _sd_hash: expect.any(String),
+      iat: expect.any(Number),
+      nonce: undefined,
+    },
+  });
+
+  return SD_JWT_VC;
+};
+
+function getPresentationDefinition(): IPresentationDefinition {
+  return {
+    id: '32f54163-7166-48f1-93d8-ff217bdb0653',
+    name: 'Conference Entry Requirements',
+    purpose: 'We can only allow people associated with Washington State business representatives into conference areas',
+    format: {
+      'vc+sd-jwt': {},
+    },
+    input_descriptors: [
+      {
+        id: 'wa_driver_license',
+        name: 'Washington State Business License',
+        purpose: 'We can only allow licensed Washington State business representatives into the WA Business Conference',
+        constraints: {
+          limit_disclosure: 'required',
+          fields: [
+            {
+              path: ['$.vct'],
+              filter: {
+                type: 'string',
+                const: 'https://high-assurance.com/StateBusinessLicense',
+              },
+            },
+            {
+              path: ['$.license.number'],
+              filter: {
+                type: 'number',
+              },
+            },
+            {
+              path: ['$.user.name'],
+              filter: {
+                type: 'string',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function getVCs(): OriginalVerifiableCredential[] {
+  return [SD_JWT_VC];
+}
+
+describe('RP and OP interaction should', () => {
+  it('succeed when calling with presentation definitions and right verifiable presentation', async () => {
+    const rpMockEntity = {
+      hexPrivateKey: '2bbd6a78be9ab2193bcf74aa6d39ab59c1d1e2f7e9ef899a38fb4d94d8aa90e2',
+      did: 'did:ethr:goerli:0x038f8d21b0446c46b05aecdc603f73831578e28857adba14de569f31f3e569c024',
+      didKey: 'did:ethr:goerli:0x038f8d21b0446c46b05aecdc603f73831578e28857adba14de569f31f3e569c024#controllerKey',
+    };
+
+    const opMockEntity = {
+      hexPrivateKey: '73d24dd0fb69abdc12e7a99d8f9a970fdc8ad90598cc64cff35b584220ace0c8',
+      did: 'did:ethr:goerli:0x03a1370d4dd249eabb23245aeb4aec988fbca598ff83db59144d89b3835371daca',
+      didKey: 'did:ethr:goerli:0x03a1370d4dd249eabb23245aeb4aec988fbca598ff83db59144d89b3835371daca#controllerKey',
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const verifyCallback = async (_args: IVerifyCallbackArgs): Promise<IVerifyCredentialResult> => ({ verified: true });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const presentationVerificationCallback: PresentationVerificationCallback = async (_args) => {
+      return { verified: true };
+    };
+
+    const rp = RP.builder({ requestVersion: SupportedVersion.SIOPv2_ID1 })
+      .withClientId(rpMockEntity.did)
+      .withScope('test')
+      .withHasher(hasher)
+      .withResponseType([ResponseType.ID_TOKEN, ResponseType.VP_TOKEN])
+      .withRedirectUri(EXAMPLE_REDIRECT_URL)
+      .withPresentationDefinition({ definition: getPresentationDefinition() }, [PropertyTarget.REQUEST_OBJECT, PropertyTarget.AUTHORIZATION_REQUEST])
+      .withPresentationVerification(presentationVerificationCallback)
+      .withWellknownDIDVerifyCallback(verifyCallback)
+      .withRevocationVerification(RevocationVerification.NEVER)
+      .withRequestBy(PassBy.VALUE)
+      .withInternalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey, SigningAlgo.ES256K)
+      .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
+      .addDidMethod('ethr')
+      .withClientMetadata({
+        client_id: WELL_KNOWN_OPENID_FEDERATION,
+        idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
+        requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
+        responseTypesSupported: [ResponseType.ID_TOKEN],
+        vpFormatsSupported: { jwt_vc: { alg: [SigningAlgo.EDDSA] } },
+        scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
+        subjectTypesSupported: [SubjectType.PAIRWISE],
+        subject_syntax_types_supported: ['did', 'did:ethr'],
+        passBy: PassBy.VALUE,
+        logo_uri: VERIFIER_LOGO_FOR_CLIENT,
+        clientName: VERIFIER_NAME_FOR_CLIENT,
+        'clientName#nl-NL': VERIFIER_NAME_FOR_CLIENT_NL + '2022100322',
+        clientPurpose: VERIFIERZ_PURPOSE_TO_VERIFY,
+        'clientPurpose#nl-NL': VERIFIERZ_PURPOSE_TO_VERIFY_NL,
+      })
+      .withSupportedVersions(SupportedVersion.SIOPv2_ID1)
+      .build();
+    const op = OP.builder()
+      .withPresentationSignCallback(presentationSignCallback)
+      .withExpiresIn(1000)
+      .withHasher(hasher)
+      .withWellknownDIDVerifyCallback(verifyCallback)
+      .addDidMethod('ethr')
+      .withInternalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey, SigningAlgo.ES256K)
+      .withRegistration({
+        authorizationEndpoint: 'www.myauthorizationendpoint.com',
+        idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
+        issuer: ResponseIss.SELF_ISSUED_V2,
+        requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
+        responseTypesSupported: [ResponseType.ID_TOKEN, ResponseType.VP_TOKEN],
+        vpFormats: { jwt_vc: { alg: [SigningAlgo.EDDSA] } },
+        scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
+        subjectTypesSupported: [SubjectType.PAIRWISE],
+        subject_syntax_types_supported: [],
+        passBy: PassBy.VALUE,
+        logo_uri: VERIFIER_LOGO_FOR_CLIENT,
+        clientName: VERIFIER_NAME_FOR_CLIENT,
+        'clientName#nl-NL': VERIFIER_NAME_FOR_CLIENT_NL + '2022100323',
+        clientPurpose: VERIFIERZ_PURPOSE_TO_VERIFY,
+        'clientPurpose#nl-NL': VERIFIERZ_PURPOSE_TO_VERIFY_NL,
+      })
+      .withSupportedVersions(SupportedVersion.SIOPv2_ID1)
+      .build();
+
+    const requestURI = await rp.createAuthorizationRequestURI({
+      correlationId: '1234',
+      nonce: 'qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg',
+      state: 'b32f0087fc9816eb813fd11f',
+    });
+
+    // Let's test the parsing
+    const parsedAuthReqURI = await op.parseAuthorizationRequestURI(requestURI.encodedUri);
+    expect(parsedAuthReqURI.authorizationRequestPayload).toBeDefined();
+    expect(parsedAuthReqURI.requestObjectJwt).toBeDefined();
+
+    const verifiedAuthReqWithJWT = await op.verifyAuthorizationRequest(parsedAuthReqURI.requestObjectJwt);
+    expect(verifiedAuthReqWithJWT.signer).toBeDefined();
+    expect(verifiedAuthReqWithJWT.issuer).toMatch(rpMockEntity.did);
+    const pex = new PresentationExchange({ allDIDs: [HOLDER_DID], allVerifiableCredentials: getVCs(), hasher });
+    const pd: PresentationDefinitionWithLocation[] = await PresentationExchange.findValidPresentationDefinitions(
+      parsedAuthReqURI.authorizationRequestPayload
+    );
+    await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
+    const verifiablePresentationResult = await pex.createVerifiablePresentation(pd[0].definition, getVCs(), presentationSignCallback, {});
+    const authenticationResponseWithJWT = await op.createAuthorizationResponse(verifiedAuthReqWithJWT, {
+      presentationExchange: {
+        verifiablePresentations: [verifiablePresentationResult.verifiablePresentation],
+        vpTokenLocation: VPTokenLocation.AUTHORIZATION_RESPONSE,
+        presentationSubmission: verifiablePresentationResult.presentationSubmission,
+      },
+    });
+    expect(authenticationResponseWithJWT.response.payload).toBeDefined();
+    expect(authenticationResponseWithJWT.response.idToken).toBeDefined();
+
+    const verifiedAuthResponseWithJWT = await rp.verifyAuthorizationResponse(authenticationResponseWithJWT.response.payload, {
+      presentationDefinitions: [{ definition: pd[0].definition, location: pd[0].location }],
+    });
+
+    expect(verifiedAuthResponseWithJWT.idToken.jwt).toBeDefined();
+    expect(verifiedAuthResponseWithJWT.idToken.payload.nonce).toMatch('qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg');
+  });
+});


### PR DESCRIPTION
Adds support for SD-JWT to be used as VPs.

The SdJwt.spec.ts has an end to end test case where a response is created based on a sd-jwt vc. 

It just adds support for the SD-JWT credential format profile, it hasn't implemented all restrictions from HAIP.

Dependant on https://github.com/Sphereon-Opensource/PEX/pull/132 to be merged and released first