### PR TITLE
fix: check presentation callback result

### DIFF
--- a/src/authorization-response/PresentationExchange.ts
+++ b/src/authorization-response/PresentationExchange.ts
@@ -344,7 +344,12 @@ export class PresentationExchange {
         // So the behavior here is to bypass it if not present
         if (verifyPresentationCallback) {
           try {
-            await verifyPresentationCallback(vpw.original as W3CVerifiablePresentation, presentationSubmission);
+            const verificationResult = await verifyPresentationCallback(vpw.original as W3CVerifiablePresentation, presentationSubmission);
+            if (!verificationResult.verified) {
+              throw new Error(
+                SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID + verificationResult.reason ? `. ${verificationResult.reason}` : ''
+              );
+            }
           } catch (error: unknown) {
             throw new Error(SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID);
           }

--- a/src/authorization-response/types.ts
+++ b/src/authorization-response/types.ts
@@ -87,7 +87,7 @@ export enum VPTokenLocation {
   TOKEN_RESPONSE = 'token_response',
 }
 
-export type PresentationVerificationResult = { verified: boolean };
+export type PresentationVerificationResult = { verified: boolean; reason?: string };
 
 export type PresentationVerificationCallback = (
   args: W3CVerifiablePresentation | CompactSdJwtVc,


### PR DESCRIPTION
We used the `verified` property in the presentation verification callback as return value, but noticed that presentations would still be marked as `'verified'` even if the presentation was invalid.

It seems the PresetnationExchange only check if an error was thrown and didn't use the return property `verified`. This PR makes sure both error and `verifier: false` are handled. 

It also adds a `reason` so the implementer can provide a reason why the verification failed.

I tried to write some tests for it, but somehow jest just straight up exists or only throws the error at the next test, even though I use await expect(Promise).rejects.toThrow(). Not sure what is happening here