### PR TITLE
fix: import response type

### DIFF
--- a/src/authorization-request/AuthorizationRequest.ts
+++ b/src/authorization-request/AuthorizationRequest.ts
@@ -12,6 +12,7 @@ import {
   RequestObjectJwt,
   RequestObjectPayload,
   RequestStateInfo,
+  ResponseType,
   ResponseURIType,
   RPRegistrationMetadataPayload,
   Schema,


### PR DESCRIPTION
Imports the response type, as the `ResponseType` from DOM was used (which isn't availalbe in AFJ  and thus type check throws an error)