### PR TITLE
fix: always verify nonce, extract nonce from VP

### DIFF
--- a/src/authorization-response/AuthorizationResponse.ts
+++ b/src/authorization-response/AuthorizationResponse.ts
@@ -157,7 +157,6 @@ export class AuthorizationResponse {
 
     const firstNonce = Array.from(allNonces)[0];
     if (allNonces.size !== 1 || typeof firstNonce !== 'string') {
-      console.log(allNonces, firstNonce, merged.nonce, verifiedIdToken.payload.nonce, oid4vp.nonce);
       throw new Error('both id token and VPs in vp token if present must have a nonce, and all nonces must be the same');
     }
     if (verifyOpts.nonce && firstNonce !== verifyOpts.nonce) {

--- a/test/IT.spec.ts
+++ b/test/IT.spec.ts
@@ -54,6 +54,7 @@ const presentationSignCallback: PresentationSignCallback = async (_args) => ({
     created: '2018-09-14T21:19:10Z',
     proofPurpose: 'authentication',
     verificationMethod: 'did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1',
+    nonce: 'qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg',
     challenge: '1f44d55f-f161-4938-a659-f8026467f126',
     domain: '4jt78h47fh47',
     jws: 'eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kTCYt5XsITJX1CxPCT8yAV-TVIw5WEuts01mq-pQy7UJiN5mgREEMGlv50aqzpqh4Qq_PbChOMqsLfRoPsnsgxD-WUcX16dUOqV0G_zS245-kronKb78cPktb3rk-BuQy72IFLN25DYuNzVBAh4vGHSrQyHUGlcTwLtjPAnKb78',


### PR DESCRIPTION
This PR makes a few improvements to the nonce extraction and verification process:
- correctly extract nonce from SD-JWT, W3C JSON-LD or W3C JWT presentation. (I'll make a small follow up pr to clean up the SD-JWT nonce a bit once https://github.com/Sphereon-Opensource/SSI-SDK/pull/183 is merged and released)
- Fix the extraction of nonce values from set using array index (always returns undefined)
- Make sure all presentations and id token and auth response use the same nonce
- make sure nonce is always defined
- check nonce against verifyOpts if provided