### PR TITLE
fix: no async in filter

### DIFF
--- a/test/PresentationExchange.spec.ts
+++ b/test/PresentationExchange.spec.ts
@@ -422,4 +422,36 @@ describe('presentation exchange manager tests', () => {
       console.log(e);
     }
   });
+
+  it("'validatePresentationsAgainstDefinitions' should fail if provided VP verification callback fails", async () => {
+    const payload: AuthorizationRequestPayload = await getPayloadVID1Val();
+    const pd: PresentationDefinitionWithLocation[] = await PresentationExchange.findValidPresentationDefinitions(payload);
+    const vcs = getVCs();
+    const pex = new PresentationExchange({ allDIDs: [HOLDER_DID], allVerifiableCredentials: vcs });
+    await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
+    const presentationSignCallback: PresentationSignCallback = async (_args) => ({
+      ...(_args.presentation as IPresentation),
+      proof: {
+        type: 'RsaSignature2018',
+        created: '2018-09-14T21:19:10Z',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1',
+        challenge: '1f44d55f-f161-4938-a659-f8026467f126',
+        domain: '4jt78h47fh47',
+        jws: 'eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kTCYt5XsITJX1CxPCT8yAV-TVIw5WEuts01mq-pQy7UJiN5mgREEMGlv50aqzpqh4Qq_PbChOMqsLfRoPsnsgxD-WUcX16dUOqV0G_zS245-kronKb78cPktb3rk-BuQy72IFLN25DYuNzVBAh4vGHSrQyHUGlcTwLtjPAnKb78',
+      },
+    });
+    const verifiablePresentationResult = await pex.createVerifiablePresentation(pd[0].definition, vcs, presentationSignCallback, {});
+
+    await expect(
+      PresentationExchange.validatePresentationsAgainstDefinitions(
+        pd,
+        [CredentialMapper.toWrappedVerifiablePresentation(verifiablePresentationResult.verifiablePresentation)],
+        () => {
+          throw new Error('Verification failed');
+        },
+        {},
+      ),
+    ).rejects.toThrow(SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID);
+  });
 });


### PR DESCRIPTION
This one took me really long to debug, but i was finally able to find out why a succesful verification event was emitted even though the presentation verification callback failed. 

The filter that had an `async` method doesn't really work, and thus it would see the returned promise value in the filter method as a truthy value (`Boolean(Promise.reject())` will still evaluate to true). It was especially weird since the error was thrown, but because it was not handled within a promise, it was an unhandled rejection.

It does mean that the presentation verification callback has had no effect on the outcome of the verification, so this seems like a serious bug to get released as soon as possible.